### PR TITLE
Update ADE Dockerfile - add git install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ ARG IMAGE_VERSION
 # Metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 
+# install git (need to run models - including Azure Verified Modules)
+RUN tdnf install -y git
+
 # install terraform
 RUN wget -O terraform.zip https://releases.hashicorp.com/terraform/1.7.4/terraform_1.7.4_linux_amd64.zip
 RUN unzip terraform.zip && rm terraform.zip


### PR DESCRIPTION
Git is required for Terraform to plan/apply modules, such as the Azure Verified Modules - a Microsoft owned initiative.
Since 99% of ADE Terraform users are going to be using modules, make sure GIT is included in the base ADE image for Terraform.